### PR TITLE
Install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 mason_packages/
 .idea/
 .DS_Store
+mapbox-gl-native/
+mason-js/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ go bindings for mapbox gl native's c++ api
 
 ## Development
 
-### Darwin Deps
+### Dev Deps
+**Darwin**:
 see inssructions [on the mblg page](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/macos/INSTALL.md), but do not build the library.
 In list form:
 * xcode
@@ -13,8 +14,11 @@ In list form:
 * xcpretty
 * jazzy
 
+**Linux**:
+todo
+
 ### install
-run the install script provided in the repo. Note, it'll install a node package, `mason-js` globaly with `npm i -g`.
+run the install script provided in the repo. Note, it'll install a node package, [`mason-js`](https://github.com/mapbox/mason-js) globally with `npm i -g`.
 ```bash
 ./install.sh
 ```
@@ -22,7 +26,7 @@ run the install script provided in the repo. Note, it'll install a node package,
 ### build/tests
 regular go tool commands (`go build`, `go test`) can be used for building the library.
 
-### Old install isntructions (depracated)
+### Old install instructions (deprecated)
 
 1. Download and build [Mapbox-GL-Native](https://github.com/mapbox/mapbox-gl-native) for your platform.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 # Mbgl
 go bindings for mapbox gl native's c++ api
 
+## Development
+
+### Darwin Deps
+see inssructions [on the mblg page](https://github.com/mapbox/mapbox-gl-native/blob/master/platform/macos/INSTALL.md), but do not build the library.
+In list form:
+* xcode
+* node
+* cmake
+* ccache
+* xcpretty
+* jazzy
+
+### install
+run the install script provided in the repo. Note, it'll install a node package, `mason-js` globaly with `npm i -g`.
+```bash
+./install.sh
+```
+
+### build/tests
+regular go tool commands (`go build`, `go test`) can be used for building the library.
+
+### Old install isntructions (depracated)
 
 1. Download and build [Mapbox-GL-Native](https://github.com/mapbox/mapbox-gl-native) for your platform.
 

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -172,7 +172,7 @@ func main() {
 	}
 	if err := png.Encode(file, img); err != nil {
 		file.Close()
-		log.Println("Failed to write %v", FOutputFilename)
+		log.Printf("Failed to write %v", FOutputFilename)
 		log.Fatal(err)
 	}
 	file.Close()

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+# check mbgl dependencies
+function check_dep {
+    arg=$1
+    which  $arg #> /dev/null
+    if [[ ! $? -eq 0 ]]; then
+        echo "dep $arg, not installed"
+        exit
+    fi
+}
+
+deps="node cmake ccache xcpretty jazzy"
+for dep in $deps; do
+    echo "checking if $dep is installed"
+    check_dep $dep
+done
+
 if [[ ! $GOPATH ]]; then
     echo "GOPATH must be set"
     exit

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+if [[ ! $GOPATH ]]; then
+    echo "GOPATH must be set"
+    exit
+fi
+
+PKG_ROOT=$GOPATH/src/github.com/go-spatial/go-mbgl
+
+
+# download and install sdk
+if [[ ! -d mapbox-gl-native ]]; then
+    git clone https://github.com/mapbox/mapbox-gl-native
+fi
+
+git fetch --all --tags --prune
+
+mkdir $PKG_ROOT/lib
+cd $PKG_ROOT/mapbox-gl-native
+
+if [[ uname -eq Darwin ]]; then
+    echo "installing for $(uname)"
+
+    git checkout tags/macos-v0.9.0
+    git reset --hard --recurse-submodules
+
+    make xpackage
+    err=$?
+    if [[ ! err -eq 0 ]]; then
+        echo "error $err"
+        exit
+    fi
+
+    if [[ -d $PKG_ROOT/lib/darwin ]]; then
+        rm -rf $PKG_ROOT/lib/darwin
+    fi
+
+    mkdir $PKG_ROOT/lib/darwin
+
+    mv $PKG_ROOT/mapbox-gl-native/build/macos/Debug/* $PKG_ROOT/lib/darwin/
+    sudo mv $PKG_ROOT/lib/darwin/Mapbox.framework /Library/Frameworks/
+else
+    echo "no install instructions for $(uname)"
+fi
+
+# install mason-js (mapbox package manager)
+cd $PKG_ROOT
+git clone https://github.com/mapbox/mason-js
+cd $PKG_ROOT/mason-js
+npm i -g
+
+# install deps
+cd $PKG_ROOT
+mason-js install
+mason-js link

--- a/mbgl/mbgl.go
+++ b/mbgl/mbgl.go
@@ -8,7 +8,7 @@ package mbgl
 #cgo CXXFLAGS: -I${SRCDIR}/../mason_packages/.link/include
 #cgo CXXFLAGS: -I${SRCDIR}/../mapbox-gl-native/include
 #cgo CXXFLAGS: -I${SRCDIR}/../mapbox-gl-native/platform/default
-#cgo LDFLAGS: -L${SRCDIR}/mason_packages/.link/lib
+#cgo LDFLAGS: -L${SRCDIR}/../mason_packages/.link/lib
 #cgo LDFLAGS: -lsqlite3 -lz
 #cgo LDFLAGS: -lmbgl-filesource -lmbgl-core
 

--- a/mbgl/mbgl_darwin.go
+++ b/mbgl/mbgl_darwin.go
@@ -1,6 +1,7 @@
 package mbgl
 
 /*
+#cgo LDFLAGS: -L${SRCDIR}/../lib/darwin
 #cgo LDFLAGS: -lmbgl-loop-darwin
 #cgo LDFLAGS: -framework Mapbox
 #cgo LDFLAGS: -framework CoreFoundation -framework CoreGraphics -framework ImageIO -framework OpenGL -framework CoreText -framework Foundation


### PR DESCRIPTION
This PR contains an install script which builds `Mapbox.framerwork` and a few library (`.a`) files and places them in appropriate locations for building `go-mbgl`.

**Notes:**
* sudo is required to place the `.framework` in `/Library/Frameworks`, the build would fail otherwise even with `-F` switch
* it will install `mason-js` globally
* tests now occasionally fail on exit
    * possibly due to the `cache` file generated by `DefaultFileSource`